### PR TITLE
Add support for overlay scrollbars

### DIFF
--- a/Windows 10.sublime-theme
+++ b/Windows 10.sublime-theme
@@ -293,6 +293,33 @@
 	},
 
 //
+// OVERLAY SCROLLBARS
+//
+	// Overlay toggle scroll bar
+	{
+		"class": "scroll_area_control",
+		"settings": ["overlay_scroll_bars"],
+		"overlay": true
+	},
+	{
+		"class": "scroll_area_control",
+		"settings": ["!overlay_scroll_bars"],
+		"overlay": false
+	},
+	// Overlay scroll bar
+	{
+		"class": "scroll_bar_control",
+		"settings": ["overlay_scroll_bars"],
+		"layer0.opacity": 0.5,
+	},
+	// Overlay puck
+	{
+		"class": "puck_control",
+		"settings": ["overlay_scroll_bars"],
+		"layer0.opacity": 0.8,
+	},
+
+//
 // EMPTY WINDOW BACKGROUND
 //
 	{


### PR DESCRIPTION
I wanted to make them like in Windows: narrow when scroll and wider when hover;
but it seems ST doesn’t support it: hover attribute have no effect.

To test: `Preferences` → `Settings — User` → `"overlay_scroll_bars": "enabled"` & restart ST.
